### PR TITLE
Do not create wx app when in CLI mode

### DIFF
--- a/flickr_to_anytool/flickr_to_any.py
+++ b/flickr_to_anytool/flickr_to_any.py
@@ -3020,7 +3020,11 @@ def gui_main():
     """Entry point for GUI version"""
     try:
         if '--cli' in sys.argv:
+            logging.info("Running in CLI mode")
             sys.argv.remove('--cli')
+            # Call the main function directly without Gooey/wx
+            main()
+            return
 
         # Create wx.App instance before using wx
         app = wx.App(False)


### PR DESCRIPTION
This fixes the issue that it is not possible to run the tool from the terminal when display is not available.